### PR TITLE
Use environment files

### DIFF
--- a/backend/src/main/kotlin/de/finatix/lodh24/backend/ai/DataImportService.kt
+++ b/backend/src/main/kotlin/de/finatix/lodh24/backend/ai/DataImportService.kt
@@ -8,6 +8,7 @@ import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser
 import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
@@ -20,6 +21,7 @@ import java.util.logging.Logger
 data class DataRecord(val values: Map<String, String>)
 
 @Service
+@ConditionalOnProperty("spring.dataimport.enabled")
 class DataImportService {
 
     @Autowired

--- a/backend/src/main/resources/application-local.yaml
+++ b/backend/src/main/resources/application-local.yaml
@@ -1,6 +1,4 @@
 spring:
-  profile:
-    active: "local"
   ai:
     vectorstore:
       milvus:

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -1,14 +1,12 @@
 spring:
-  profile:
-    active: "local"
   ai:
     vectorstore:
       milvus:
         client:
-          host: "localhost"
+          host: ${VDB_URL}
           port: 19530
-          username: "root"
-          password: "milvus"
+          username: ${VDB_USER}
+          password: ${VDB_PASSWORD}
         databaseName: "default"
         collectionName: "vector_store"
         embeddingDimension: 1536
@@ -20,8 +18,8 @@ spring:
       max-attempts: 1
   datasource:
     url: jdbc:postgresql://localhost:5432/conversation
-    username: user
-    password: password
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -31,4 +31,5 @@ spring:
     enabled: true
     locations: classpath:db/migration
     baseline-on-migrate: true
-
+  dataimport:
+    enabled: true


### PR DESCRIPTION
Define different application.yaml for local and production environment.
This is in preparation for the deployment on the server.

With this change, it will be required to set the `OPENAI_API_KEY` as environment variable.
This will be written to the `spring.ai.openai.api-key` property.

Furthermore the DataImportService can be disabled via the spring.dataimport.enabled property.
This circumvents the generation of descriptions for vast amounts of datasets upon starting the project.